### PR TITLE
Adding why Logregator my lose logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ with the following items.
 -   What is the responsibility of a developer in order to
     take advantage of PCF logging system?
 
+
+### References
+
+- [Why Loggregator may lose logs](https://community.pivotal.io/s/article/Why-Loggregator-may-Lose-Logs)
+
 ## Resiliency - Application Resiliency
 
 ### Trouble-shooting


### PR DESCRIPTION
The following article describes how the logs are forwarded from a cell to the doppler and states how many log messages are lost in a PAS with version 2.0. (https://community.pivotal.io/s/article/Why-Loggregator-may-Lose-Logs)